### PR TITLE
Firmware version 1.6.2 - Logic for lost GPS delays

### DIFF
--- a/firmware/ptSolar/GPS.cpp
+++ b/firmware/ptSolar/GPS.cpp
@@ -868,9 +868,11 @@ bool GPS::getAPRSFrequency(char *sz) {
  * @note: Returns a 6-character Maidenhead grid square.
  */
 void GPS::getGridSquare(char *sz, uint8_t precision) {
-	Serial.println("");
-	Serial.print(F("GridSq -"));
-	Serial.println(precision);
+	if (this->_debugLevel > 1) {
+		Serial.println("");
+		Serial.print(F("GridSq -"));
+		Serial.println(precision);
+	}
 
 	if (precision != 6) precision = 4;
 
@@ -906,8 +908,10 @@ void GPS::getGridSquare(char *sz, uint8_t precision) {
 
   if (precision == 4) {
     sz[4] = '\0';
-	Serial.println(sz);
-	return;
+
+		if (this->_debugLevel > 0) Serial.println(sz);
+
+		return;
   }
 
   // ----- Subsquare (a-x) -----
@@ -927,7 +931,7 @@ void GPS::getGridSquare(char *sz, uint8_t precision) {
   sz[5] = 'a' + subLat;
   sz[6] = '\0';
 
-  Serial.println(sz);
+  if (this->_debugLevel > 0) Serial.println(sz);
 
 }
 
@@ -946,18 +950,21 @@ void GPS::convertLatLon() {
 	uint32_t min_x10000;
 	uint32_t add_uDeg;
 	uint8_t i;
-Serial.println("");
-Serial.print(F("Lat/Lon "));
-Serial.print(this->_szLatitude);
-Serial.print(F(", "));
-Serial.println(this->_szLongitude);	
+
+	if (this->_debugLevel > 1) {
+		Serial.println("");
+		Serial.print(F("Lat/Lon "));
+		Serial.print(this->_szLatitude);
+		Serial.print(F(", "));
+		Serial.println(this->_szLongitude);	
+	}
 
 
 	if (this->_szLatitude[0] == '\0' || this->_szLongitude[0] == '\0') {
 		//we don't have valid lat/lon strings - just return
 		this->_iLatitude = 0;
 		this->_iLongitude = 0;
-Serial.println(F("!!! INVALID !!!"));
+		Serial.println(F("! INVLD !"));
 		return;
 	}
 
@@ -1027,7 +1034,9 @@ Serial.println(F("!!! INVALID !!!"));
   if (this->_cLongitudeHemi == 'W') 
   	this->_iLongitude = -this->_iLongitude;
 
-Serial.print(this->_iLatitude);
-Serial.print(F(", "));
-Serial.println(this->_iLongitude);
+	if (this->_debugLevel > 1) {
+		Serial.print(this->_iLatitude);
+		Serial.print(F(", "));
+		Serial.println(this->_iLongitude);
+	}
 }

--- a/firmware/ptSolar/ptConfig.cpp
+++ b/firmware/ptSolar/ptConfig.cpp
@@ -11,6 +11,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Version History:
+Version 1.1.3 - May 31, 2026 - Fixed an issue where the Hourly Reboot and Delay for GPS Fix parameters were being read in the wrong order.
 Version 1.1.2 - April 11, 2026 - Fixed potential buffer overfow issue with the status message.
 Version 1.1.1 - July 20, 2025 - Synchronized the ptFlex and ptSolar code bases to be parameterized by the TRACKER_PTFLEX and TRACKER_PTSOLAR defines.
 Version 1.1.0 - July 12, 2025 - Updated to PT0101 configuration format, which simplied a few unused parameters.
@@ -353,18 +354,17 @@ void ptConfig::readConfigParam(char *szParam, int iMaxLen) {
           this->_config.I2cBME280 = szParam[0] == '1';
 
 
-
           //Disable GPS during transmission
           this->readConfigParam(szParam, sizeof(szParam));
           this->_config.DisableGPSDuringXmit = szParam[0] == '1';    //Disable the GPS during transmission
 
-          this->readConfigParam(szParam, sizeof(szParam));
-          this->_config.DelayXmitUntilGPSFix = szParam[0] == '1';   //Delay up to 50 seconds for a GPS fix before transmitting 
-
           //Hourly Reboot
           this->readConfigParam(szParam, sizeof(szParam));
           this->_config.HourlyReboot = szParam[0] == '1';    //Reboot the system every hour
-    
+
+          //Delay for GPS fix before transmitting
+          this->readConfigParam(szParam, sizeof(szParam));
+          this->_config.DelayXmitUntilGPSFix = szParam[0] == '1';   //Delay up to 50 seconds for a GPS fix before transmitting 
 
 
           unsigned int iCheckSum = 0;
@@ -541,7 +541,9 @@ void ptConfig::readConfigParam(char *szParam, int iMaxLen) {
     else Serial.write("0");
     Serial.write(0x09);
 
-    Serial.print(this->_config.DelayXmitUntilGPSFix, DEC);
+    //Delay for GPS fix before transmitting
+    if (this->_config.DelayXmitUntilGPSFix) Serial.write("1");
+    else Serial.write("0");
     Serial.write(0x04);      //End of string
 
     wdt_reset();    //reset the watchdog timer

--- a/firmware/ptSolar/ptSolar.ino
+++ b/firmware/ptSolar/ptSolar.ino
@@ -300,7 +300,7 @@ void loop() {
     }
 
     break;
-  case 3: {
+  case 3:
     //Use Time Slotting to determine when to transmit
     static unsigned long ulSlotTriggeredMillis = 0;
     iSeconds = GPSParser.getGPSSeconds();
@@ -331,7 +331,6 @@ void loop() {
     }
 
     break;
-  }
   case 4:
     //This is a voltage-checked time delay.  It will wait X seconds, but then also wait for the system (solar) voltage to be above a threshold before transmitting
     msDelay = (unsigned long)Config.getMinTimeBetweenXmits() * 1000;    //cast this to unsigned long

--- a/firmware/ptSolar/ptSolar.ino
+++ b/firmware/ptSolar/ptSolar.ino
@@ -64,7 +64,7 @@ Before programming for the first time, the ATmega fuses must be set.
 
 
 #define DELAY_MS_BETWEEN_XMITS 1250   //How many MS to delay between subsequent packets (as in between GPGGA and GPRMC strings
-#define INVALID_GPS_DELAY 60000    //Max additional ms to wait for a GPS fix before transmitting anyway
+#define INVALID_GPS_DELAY 50000    //Max additional ms to wait for a GPS fix before transmitting anyway
 #define METERS_TO_FEET 3.2808399
 
 //Debugging options
@@ -206,6 +206,7 @@ void loop() {
     //This is no logic to beacon intervals - just plan old time delays
     msDelay = (unsigned long)Config.getBeaconSimpleDelay() * 1000;    //cast this to unsigned long
     if (!GPSParser.FixValid()) {
+      Tracker.debugMessage(ptTracker::DEBUG_GPS_INVALID_LOCK);
       msDelay += INVALID_GPS_DELAY;
     }
 
@@ -253,8 +254,11 @@ void loop() {
       }
     } else {
       //No GPS fix - use the high speed delay + GPS fix timeout before transmitting anyway
+      Tracker.debugMessage(ptTracker::DEBUG_GPS_INVALID_LOCK);
+
       msDelay = (unsigned long)Config.getBeaconSpeedDelayHigh() * 1000;
       if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
+        Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT_CONTINUE);
         bXmit = true;
       }
     }
@@ -293,8 +297,11 @@ void loop() {
       }
     } else {
       //No GPS fix - use the low altitude delay + GPS fix timeout before transmitting anyway
+      Tracker.debugMessage(ptTracker::DEBUG_GPS_INVALID_LOCK);
+
       msDelay = (unsigned long)Config.getBeaconAltitudeDelayLow() * 1000;
       if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
+        Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT_CONTINUE);
         bXmit = true;
       }
     }
@@ -302,32 +309,24 @@ void loop() {
     break;
   case 3:
     //Use Time Slotting to determine when to transmit
-    static unsigned long ulSlotTriggeredMillis = 0;
     iSeconds = GPSParser.getGPSSeconds();
 
     if (iSeconds == Config.getBeaconSlot1() || iSeconds == (Config.getBeaconSlot1() + 1) || iSeconds == Config.getBeaconSlot2() || iSeconds == (Config.getBeaconSlot2() + 1)) {
       if (Config.getDelayXmitUntilGPSFix()) {
         if (GPSParser.FixValid()) {
-          bXmit = true;
-          ulSlotTriggeredMillis = 0;
+          bXmit = true;   //have a valid fix, and it's in our slot. Just transmit
         } else {
-          if (ulSlotTriggeredMillis == 0) {
-            ulSlotTriggeredMillis = millis();
-          }
-          Serial.print(F("No GPS - "));
-          if ((millis() - ulSlotTriggeredMillis) > INVALID_GPS_DELAY) {
-            Serial.println(F("Xmit anyway"));
+          //See if we've haven't transmitted within the INVALID_GPS_DELAY time window.  If we haven't, then transmit anyway
+          if ((millis() - Aprs.getLastTransmitMillis()) > INVALID_GPS_DELAY) {
+            Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT_CONTINUE);
             bXmit = true;
-            ulSlotTriggeredMillis = 0;
           } else {
-            Serial.println(F("Delay"));
+            Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT);
           }
         }
       } else {
-        bXmit = true;
+        bXmit = true;   //we don't care about the GPS fix, and it's in our slot. Just transmit
       }
-    } else {
-      ulSlotTriggeredMillis = 0;    //reset when outside the slot window
     }
 
     break;
@@ -347,13 +346,13 @@ void loop() {
           //we don't have a valid GPS fix - Allow up to msDelay + 60s to wait for a fix
 
           if (Config.getDelayXmitUntilGPSFix()) {
-            Serial.print(F("No GPS - "));
+            Tracker.debugMessage(ptTracker::DEBUG_GPS_INVALID_LOCK);
             if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
               //we've waited long enough for a fix - transmit anyway
-              Serial.println(F("Xmit anyway"));
+              Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT_CONTINUE);
               bXmit = true;
             } else {
-              Serial.println(F("Delay"));
+              Tracker.debugMessage(ptTracker::DEBUG_DELAY_XMIT);
             }
           } else {
             bXmit = true;    //we have a valid GPS fix - transmit

--- a/firmware/ptSolar/ptSolar.ino
+++ b/firmware/ptSolar/ptSolar.ino
@@ -20,7 +20,7 @@ Before programming for the first time, the ATmega fuses must be set.
 */
 
 
-#define FIRMWARE_VERSION "1.6.1"
+#define FIRMWARE_VERSION "1.6.2"
 #define CONFIG_PROMPT "\n\n# "
 #include "BoardDef.h"   //defines if this is a ptFlex or ptSolar PCB board
 
@@ -28,8 +28,6 @@ Before programming for the first time, the ATmega fuses must be set.
 #define __PROG_TYPES_COMPAT__
 #include <avr/pgmspace.h>
 #include <avr/wdt.h>
-
-#include "MemoryFree.h"
 
 #include "ptConfig.h"
 #include "Modem.h"
@@ -64,8 +62,9 @@ Before programming for the first time, the ATmega fuses must be set.
 //PC5 is SCL
 //PC6 is reset and not available
 
-//How many MS to delay between subsequent packets (as in between GPGGA and GPRMC strings
-#define DELAY_MS_BETWEEN_XMITS 1250
+
+#define DELAY_MS_BETWEEN_XMITS 1250   //How many MS to delay between subsequent packets (as in between GPGGA and GPRMC strings
+#define INVALID_GPS_DELAY 60000    //Max additional ms to wait for a GPS fix before transmitting anyway
 #define METERS_TO_FEET 3.2808399
 
 //Debugging options
@@ -206,8 +205,11 @@ void loop() {
   case 0:
     //This is no logic to beacon intervals - just plan old time delays
     msDelay = (unsigned long)Config.getBeaconSimpleDelay() * 1000;    //cast this to unsigned long
-    
-     if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+    if (!GPSParser.FixValid()) {
+      msDelay += INVALID_GPS_DELAY;
+    }
+
+    if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
       //we've waited long enough - transmit
       bXmit = true;
     }
@@ -216,35 +218,43 @@ void loop() {
   case 1:
     //This is for Speed-based beaconing
 
-    fSpeed = GPSParser.Knots();        //get the current speed
-    if (fSpeed > fMaxSpeed) fMaxSpeed = fSpeed;
+    if (GPSParser.FixValid()) {
+      fSpeed = GPSParser.Knots();        //get the current speed
+      if (fSpeed > fMaxSpeed) fMaxSpeed = fSpeed;
 
-    if (fMaxSpeed < Config.getBeaconSpeedThreshLow()) {
-      //we're in the slow range
-      msDelay = (unsigned long)Config.getBeaconSpeedDelayLow() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
-        bXmit = true;
+      if (fMaxSpeed < Config.getBeaconSpeedThreshLow()) {
+        //we're in the slow range
+        msDelay = (unsigned long)Config.getBeaconSpeedDelayLow() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
       }
-    }
 
-    if (fSpeed >= Config.getBeaconSpeedThreshLow() && fSpeed < Config.getBeaconSpeedThreshHigh()) {
-      //we're in the medium range
-      msDelay = (unsigned long)Config.getBeaconSpeedDelayMid() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
-        bXmit = true;
+      if (fSpeed >= Config.getBeaconSpeedThreshLow() && fSpeed < Config.getBeaconSpeedThreshHigh()) {
+        //we're in the medium range
+        msDelay = (unsigned long)Config.getBeaconSpeedDelayMid() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
       }
-    }
 
-    if (fSpeed >= Config.getBeaconSpeedThreshHigh()) {
-      //we're in the fast range
-      msDelay = (unsigned long)Config.getBeaconSpeedDelayHigh() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
+      if (fSpeed >= Config.getBeaconSpeedThreshHigh()) {
+        //we're in the fast range
+        msDelay = (unsigned long)Config.getBeaconSpeedDelayHigh() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
+      }
+    } else {
+      //No GPS fix - use the high speed delay + GPS fix timeout before transmitting anyway
+      msDelay = (unsigned long)Config.getBeaconSpeedDelayHigh() * 1000;
+      if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
         bXmit = true;
       }
     }
@@ -253,44 +263,75 @@ void loop() {
   case 2:
     //This is for Altitude-based beaconing
 
-    if (fCurrentAlt < Config.getBeaconAltitudeThreshLow()) {
-      //we're in the low phase of the flight - we'll typically send packets more frequently close to the ground
-      msDelay = (unsigned long)Config.getBeaconAltitudeDelayLow() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
-        bXmit = true;
+    if (GPSParser.FixValid()) {
+      if (fCurrentAlt < Config.getBeaconAltitudeThreshLow()) {
+        //we're in the low phase of the flight - we'll typically send packets more frequently close to the ground
+        msDelay = (unsigned long)Config.getBeaconAltitudeDelayLow() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
       }
-    }
-    if (fCurrentAlt >= Config.getBeaconAltitudeThreshLow() && fCurrentAlt < Config.getBeaconAltitudeThreshHigh()) {
-      //we're in the mid-phase of the flight.  We'll transmit regularly in here
-      msDelay = (unsigned long)Config.getBeaconAltitudeDelayMid() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
-        bXmit = true;
+      if (fCurrentAlt >= Config.getBeaconAltitudeThreshLow() && fCurrentAlt < Config.getBeaconAltitudeThreshHigh()) {
+        //we're in the mid-phase of the flight.  We'll transmit regularly in here
+        msDelay = (unsigned long)Config.getBeaconAltitudeDelayMid() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
       }
-    }
-    if (fCurrentAlt >= Config.getBeaconAltitudeThreshHigh()) {
-      //we're in the top-phase of the flight.  Transmit more frequenly to get better burst resolution?
-      msDelay = (unsigned long)Config.getBeaconAltitudeDelayHigh() * 1000;    //cast this to unsigned long
-      
-      if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
-        //we've waited long enough for this speed - transmit
+      if (fCurrentAlt >= Config.getBeaconAltitudeThreshHigh()) {
+        //we're in the top-phase of the flight.  Transmit more frequenly to get better burst resolution?
+        msDelay = (unsigned long)Config.getBeaconAltitudeDelayHigh() * 1000;    //cast this to unsigned long
+
+        if ((millis() - Aprs.getLastTransmitMillis()) > msDelay) {
+          //we've waited long enough for this speed - transmit
+          bXmit = true;
+        }
+      }
+    } else {
+      //No GPS fix - use the low altitude delay + GPS fix timeout before transmitting anyway
+      msDelay = (unsigned long)Config.getBeaconAltitudeDelayLow() * 1000;
+      if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
         bXmit = true;
       }
     }
 
     break;
-  case 3:
+  case 3: {
     //Use Time Slotting to determine when to transmit
+    static unsigned long ulSlotTriggeredMillis = 0;
     iSeconds = GPSParser.getGPSSeconds();
 
     if (iSeconds == Config.getBeaconSlot1() || iSeconds == (Config.getBeaconSlot1() + 1) || iSeconds == Config.getBeaconSlot2() || iSeconds == (Config.getBeaconSlot2() + 1)) {
-      bXmit = true;
+      if (Config.getDelayXmitUntilGPSFix()) {
+        if (GPSParser.FixValid()) {
+          bXmit = true;
+          ulSlotTriggeredMillis = 0;
+        } else {
+          if (ulSlotTriggeredMillis == 0) {
+            ulSlotTriggeredMillis = millis();
+          }
+          Serial.print(F("No GPS - "));
+          if ((millis() - ulSlotTriggeredMillis) > INVALID_GPS_DELAY) {
+            Serial.println(F("Xmit anyway"));
+            bXmit = true;
+            ulSlotTriggeredMillis = 0;
+          } else {
+            Serial.println(F("Delay"));
+          }
+        }
+      } else {
+        bXmit = true;
+      }
+    } else {
+      ulSlotTriggeredMillis = 0;    //reset when outside the slot window
     }
 
     break;
+  }
   case 4:
     //This is a voltage-checked time delay.  It will wait X seconds, but then also wait for the system (solar) voltage to be above a threshold before transmitting
     msDelay = (unsigned long)Config.getMinTimeBetweenXmits() * 1000;    //cast this to unsigned long
@@ -308,7 +349,7 @@ void loop() {
 
           if (Config.getDelayXmitUntilGPSFix()) {
             Serial.print(F("No GPS - "));
-            if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + 60000)) {
+            if ((millis() - Aprs.getLastTransmitMillis()) > (msDelay + INVALID_GPS_DELAY)) {
               //we've waited long enough for a fix - transmit anyway
               Serial.println(F("Xmit anyway"));
               bXmit = true;
@@ -372,13 +413,7 @@ void loop() {
       //we are having GPS fix issues - issue an annunciation
       Tracker.annunciate('l');
     }
-  }
-
-  //see if we're tracking free memory (debugging)
-  #ifdef  MEMORY_FREE_H
-    // Serial.print(F("Mem: "));
-    // Serial.println(freeMemory());
-  #endif  
+  } 
 }
 
 

--- a/firmware/ptSolar/ptSolar.ino
+++ b/firmware/ptSolar/ptSolar.ino
@@ -108,7 +108,7 @@ void setup() {
   Tracker.annunciate('k');
 
   //Additional configurations for the APRS Modem
-  Aprs.setDebugLevel(2);
+  Aprs.setDebugLevel(1);
   Aprs.setTxDelay(Config.getRadioTxDelay());
   Aprs.setCourtesyTone(Config.getRadioCourtesyTone());
 
@@ -127,7 +127,7 @@ void setup() {
   }
   
   GPSParser.setDebugNEMA(true);    ///TODO: Need to pull this from Configuration
-  GPSParser.setDebugLevel(2);    //Get full verbose output from the GPS
+  GPSParser.setDebugLevel(1);    //Get full verbose output from the GPS
 }
 
 

--- a/firmware/ptSolar/ptTracker.cpp
+++ b/firmware/ptSolar/ptTracker.cpp
@@ -11,6 +11,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Version History:
+Version 1.0.1 - June 6, 2025 - Added debugMessage() function to allow for debug messages to be sent to the serial port without repeating string literals throughout code
 Version 1.0.0 - March 9, 2025 - Initial Release.
 
 */
@@ -190,4 +191,29 @@ void ptTracker::audioTone(int length) {
     //Set the pins back to inputs to save power
     pinMode(this->_pinLED, INPUT);  
     pinMode(this->_pinPiezo, INPUT);
+}
+
+
+/**
+ * @brief Annunciate a tone on the audio annunciator.
+ * @param length The length of the tone in microseconds.
+ * @note This function is called regardless of whether the audio annunciator is enabled or not, in order to provide consistent timing to the LED annunciator.
+ */
+void ptTracker::debugMessage(DebugMessage message) {
+    wdt_reset();    //reset the watchdog timer
+
+    switch (message) {
+        case DEBUG_GPS_INVALID_LOCK:
+            Serial.println(F("GPS-Invalid"));
+            break;
+        case DEBUG_GPS_LOCK:
+            Serial.println(F("GPS-Lock"));
+            break;
+        case DEBUG_DELAY_XMIT:
+            Serial.println(F("Xmit-Delay"));
+            break;
+        case DEBUG_DELAY_XMIT_CONTINUE:
+            Serial.println(F("Xmit-Continue"));
+            break;
+    }
 }

--- a/firmware/ptSolar/ptTracker.h
+++ b/firmware/ptSolar/ptTracker.h
@@ -29,6 +29,14 @@ You should have received a copy of the GNU General Public License along with thi
 
 class ptTracker {
   public:
+      //Enums for the debugMessages
+    enum DebugMessage {
+        DEBUG_GPS_INVALID_LOCK = 0,
+        DEBUG_GPS_LOCK = 1,
+        DEBUG_DELAY_XMIT = 2,
+        DEBUG_DELAY_XMIT_CONTINUE = 3
+    };
+    
     // Constructor
     ptTracker(uint8_t pinLED, uint8_t pinPiezo, uint8_t pinBattery, uint8_t annunciateMode);
 
@@ -38,6 +46,9 @@ class ptTracker {
     void setAnnunciateMode(uint8_t mode) { this->_annunciateMode = mode; }
     uint8_t getAnnunciateMode() { return this->_annunciateMode; }
     void (*reboot) (void) = 0;    //function pointer to the reboot the Tracker
+    void debugMessage(DebugMessage message);
+
+
 
   private:
     // Private Variables


### PR DESCRIPTION
Added logic to the first three beacon modes to delay transmission for up to 50 seconds if the GPS does not have a valid lock.